### PR TITLE
Upgrade to CosmWasm 1.0.0 Beta 5 / ProvWasm 1.0.0 Beta 2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,6 +43,8 @@ optimize = """docker run --rm -v "$(pwd)":/code \
 provwasm-std = { version = "1.0.0-beta"}
 cosmwasm-std = { version = "1.0.0-beta" }
 cosmwasm-storage = { version = "1.0.0-beta" }
+cw-storage-plus = "0.8.0"
+cw2 = "0.8.1"
 schemars = "0.8.3"
 serde = { version = "1.0.127", default-features = false, features = ["derive"] }
 serde-json-wasm = { version = "0.3.1" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,16 +40,14 @@ optimize = """docker run --rm -v "$(pwd)":/code \
 """
 
 [dependencies]
-provwasm-std = { version = "0.16.0"}
-cosmwasm-std = { version = "0.16.2" }
-cosmwasm-storage = { version = "0.16.2" }
-cw-storage-plus = "0.8.0"
-cw2 = "0.8.1"
+provwasm-std = { version = "1.0.0-beta"}
+cosmwasm-std = { version = "1.0.0-beta" }
+cosmwasm-storage = { version = "1.0.0-beta" }
 schemars = "0.8.3"
 serde = { version = "1.0.127", default-features = false, features = ["derive"] }
 serde-json-wasm = { version = "0.3.1" }
 thiserror = { version = "1.0.26" }
 
 [dev-dependencies]
-provwasm-mocks = { version = "0.16.0" }
-cosmwasm-schema = { version = "0.16.2" }
+provwasm-mocks = { version = "1.0.0-beta" }
+cosmwasm-schema = { version = "1.0.0-beta" }

--- a/src/contract.rs
+++ b/src/contract.rs
@@ -1,8 +1,8 @@
 use cosmwasm_std::{
-    coin, to_binary, Attribute, BankMsg, Binary, CosmosMsg, Decimal, Deps, DepsMut, Env,
+    coin, entry_point, to_binary, Attribute, BankMsg, Binary, CosmosMsg, Decimal, Deps, DepsMut, Env,
     MessageInfo, QuerierWrapper, Response, StdError, StdResult, Uint128,
 };
-use provwasm_std::{bind_name, NameBinding, ProvenanceMsg, ProvenanceQuerier, Scope};
+use provwasm_std::{bind_name, NameBinding, ProvenanceQuerier, ProvenanceQuery, Scope};
 use std::ops::Mul;
 
 use crate::error::ContractError;
@@ -12,7 +12,7 @@ use crate::helper::{
     REFUND_AMOUNT_KEY, REGISTERED_DENOM_KEY, SCOPE_ID_KEY, TOTAL_OWED_KEY, TOTAL_REMAINING_KEY,
 };
 use crate::make_payment::MakePaymentV1;
-use crate::msg::{ExecuteMsg, InitMsg, MigrateMsg, QueryMsg};
+use crate::msg::{ExecuteMsg, InitMsg, MigrateMsg, ProvenanceMsgV2, QueryMsg};
 use crate::oracle_approval::OracleApprovalV1;
 use crate::register_payable::RegisterPayableMarkerV1;
 use crate::state::{
@@ -20,12 +20,13 @@ use crate::state::{
 };
 
 /// Initialize the contract
+#[entry_point]
 pub fn instantiate(
-    deps: DepsMut,
+    deps: DepsMut<ProvenanceQuery>,
     env: Env,
     info: MessageInfo,
     msg: InitMsg,
-) -> Result<Response<ProvenanceMsg>, StdError> {
+) -> Result<Response<ProvenanceMsgV2>, StdError> {
     // Ensure no funds were sent with the message
     if !info.funds.is_empty() {
         let err = "purchase funds are not allowed to be sent during init";
@@ -55,11 +56,11 @@ pub fn instantiate(
     })?;
 
     // Create a message that will bind a restricted name to the contract address.
-    let bind_name_msg = bind_name(
+    let bind_name_msg = ProvenanceMsgV2::from_cosmos(bind_name(
         &msg.contract_name,
         env.contract.address,
         NameBinding::Restricted,
-    )?;
+    )?);
 
     // Dispatch messages and emit event attributes
     Ok(Response::new()
@@ -68,7 +69,8 @@ pub fn instantiate(
 }
 
 /// Query contract state.
-pub fn query(deps: Deps, _env: Env, msg: QueryMsg) -> StdResult<Binary> {
+#[entry_point]
+pub fn query(deps: Deps<ProvenanceQuery>, _env: Env, msg: QueryMsg) -> StdResult<Binary> {
     match msg {
         QueryMsg::QueryState {} => {
             let state = config_read(deps.storage).load()?;
@@ -85,12 +87,13 @@ pub fn query(deps: Deps, _env: Env, msg: QueryMsg) -> StdResult<Binary> {
 }
 
 /// Handle purchase messages.
+#[entry_point]
 pub fn execute(
-    deps: DepsMut,
+    deps: DepsMut<ProvenanceQuery>,
     _env: Env,
     info: MessageInfo,
     msg: ExecuteMsg,
-) -> Result<Response<ProvenanceMsg>, ContractError> {
+) -> Result<Response<ProvenanceMsgV2>, ContractError> {
     match msg {
         ExecuteMsg::RegisterPayable {
             payable_type,
@@ -119,10 +122,10 @@ pub fn execute(
 }
 
 fn register_payable(
-    deps: DepsMut,
+    deps: DepsMut<ProvenanceQuery>,
     info: MessageInfo,
     register: RegisterPayableMarkerV1,
-) -> Result<Response<ProvenanceMsg>, ContractError> {
+) -> Result<Response<ProvenanceMsgV2>, ContractError> {
     let state = config(deps.storage).load()?;
     if state.payable_type != register.payable_type {
         return Err(ContractError::InvalidPayable {
@@ -133,7 +136,7 @@ fn register_payable(
             ),
         });
     }
-    let mut messages: Vec<CosmosMsg<ProvenanceMsg>> = vec![];
+    let mut messages: Vec<CosmosMsg<ProvenanceMsgV2>> = vec![];
     let mut attributes: Vec<Attribute> = vec![];
     let fee_charge_response = validate_fee_params_get_messages(&info, &state)?;
     // TODO: Tag the payable uuid on the scope as an attribute
@@ -201,13 +204,13 @@ fn register_payable(
         .add_attributes(attributes))
 }
 
-fn get_scope_by_id(querier: &QuerierWrapper, scope_id: &str) -> StdResult<Scope> {
+fn get_scope_by_id(querier: &QuerierWrapper<ProvenanceQuery>, scope_id: &str) -> StdResult<Scope> {
     ProvenanceQuerier::new(querier).get_scope(scope_id)
 }
 
 struct FeeChargeResponse {
-    fee_charge_message: Option<CosmosMsg<ProvenanceMsg>>,
-    fee_refund_message: Option<CosmosMsg<ProvenanceMsg>>,
+    fee_charge_message: Option<CosmosMsg<ProvenanceMsgV2>>,
+    fee_refund_message: Option<CosmosMsg<ProvenanceMsgV2>>,
     refund_amount: u128,
     oracle_fee_amount_kept: u128,
 }
@@ -289,11 +292,11 @@ fn validate_fee_params_get_messages(
 }
 
 fn oracle_approval(
-    deps: DepsMut,
+    deps: DepsMut<ProvenanceQuery>,
     info: MessageInfo,
     oracle_approval: OracleApprovalV1,
-) -> Result<Response<ProvenanceMsg>, ContractError> {
-    let mut messages: Vec<CosmosMsg<ProvenanceMsg>> = vec![];
+) -> Result<Response<ProvenanceMsgV2>, ContractError> {
+    let mut messages: Vec<CosmosMsg<ProvenanceMsgV2>> = vec![];
     // Oracle approval should not require any funds
     if !info.funds.is_empty() {
         return Err(ContractError::FundsPresent);
@@ -342,10 +345,10 @@ fn oracle_approval(
 }
 
 fn make_payment(
-    deps: DepsMut,
+    deps: DepsMut<ProvenanceQuery>,
     info: MessageInfo,
     make_payment: MakePaymentV1,
-) -> Result<Response<ProvenanceMsg>, ContractError> {
+) -> Result<Response<ProvenanceMsgV2>, ContractError> {
     let mut payables_bucket = payable_meta_storage(deps.storage);
     let mut target_payable = match payables_bucket.load(make_payment.payable_uuid.as_bytes()) {
         Ok(meta) => {
@@ -403,7 +406,7 @@ fn make_payment(
     let scope = get_scope_by_id(&deps.querier, target_payable.scope_id.as_str())?;
     let payee = scope.value_owner_address;
     let payment_message = CosmosMsg::Bank(BankMsg::Send {
-        to_address: payee.clone(),
+        to_address: payee.to_string(),
         amount: vec![coin(payment_amount, &target_payable.payable_denom)],
     });
     // Subtract payment amount from tracked total
@@ -420,11 +423,12 @@ fn make_payment(
         .add_attribute(PAYMENT_AMOUNT_KEY, payment_amount.to_string())
         .add_attribute(TOTAL_REMAINING_KEY, target_payable.payable_remaining_owed)
         .add_attribute(PAYER_KEY, &info.sender.to_string())
-        .add_attribute(PAYEE_KEY, &payee))
+        .add_attribute(PAYEE_KEY, payee.as_str()))
 }
 
 /// Called when migrating a contract instance to a new code ID.
-pub fn migrate(_deps: DepsMut, _env: Env, _msg: MigrateMsg) -> Result<Response, ContractError> {
+#[entry_point]
+pub fn migrate(_deps: DepsMut<ProvenanceQuery>, _env: Env, _msg: MigrateMsg) -> Result<Response, ContractError> {
     Ok(Response::default())
 }
 
@@ -436,7 +440,7 @@ mod tests {
     use crate::error::ContractError::Std;
     use cosmwasm_std::testing::{mock_env, mock_info};
     use cosmwasm_std::StdError::GenericErr;
-    use cosmwasm_std::{from_binary, CosmosMsg, Decimal};
+    use cosmwasm_std::{from_binary, CosmosMsg, Decimal, Addr};
     use provwasm_mocks::mock_dependencies;
     use provwasm_std::{NameMsgParams, Party, PartyType, ProvenanceMsgParams};
 
@@ -2013,9 +2017,9 @@ mod tests {
     }
 
     fn test_instantiate(
-        deps: DepsMut,
+        deps: DepsMut<ProvenanceQuery>,
         args: InstArgs,
-    ) -> Result<Response<ProvenanceMsg>, StdError> {
+    ) -> Result<Response<ProvenanceMsgV2>, StdError> {
         instantiate(
             deps,
             args.env,
@@ -2048,11 +2052,11 @@ mod tests {
             scope_id: scope_id.into(),
             specification_id: "duped_spec_id".into(),
             owners: vec![Party {
-                address: owner_address.into(),
+                address: Addr::unchecked(owner_address),
                 role: PartyType::Owner,
             }],
             data_access: vec![],
-            value_owner_address: owner_address.into(),
+            value_owner_address: Addr::unchecked(owner_address),
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,6 +7,3 @@ pub mod msg;
 pub mod oracle_approval;
 pub mod register_payable;
 pub mod state;
-
-#[cfg(target_arch = "wasm32")]
-cosmwasm_std::create_entry_points_with_migration!(contract);

--- a/src/msg.rs
+++ b/src/msg.rs
@@ -1,5 +1,4 @@
-use cosmwasm_std::{CosmosMsg, CustomMsg, Decimal, Uint128};
-use provwasm_std::{ProvenanceMsg, ProvenanceMsgParams, ProvenanceRoute};
+use cosmwasm_std::{Decimal, Uint128};
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
@@ -60,35 +59,3 @@ pub type QueryResponse = State;
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
 #[serde(rename_all = "snake_case")]
 pub struct MigrateMsg {}
-
-/// FIXME: This will be fixed in 1.0.1-beta of provwasm.  This struct exists as a clone of
-/// FIXME: ProvenanceMsg, but implements CustomMsg.  CosmWasm 1.0.0-betaX does not allow exported
-/// FIXME: entry_point functions to expose Response<X> values, where X does not implement CustomMsg.
-#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
-#[serde(rename_all = "snake_case")]
-pub struct ProvenanceMsgV2 {
-    pub route: ProvenanceRoute,
-    pub params: ProvenanceMsgParams,
-    pub version: String,
-}
-impl ProvenanceMsgV2 {
-    pub fn from_cosmos(msg: CosmosMsg<ProvenanceMsg>) -> CosmosMsg<ProvenanceMsgV2> {
-        match msg {
-            CosmosMsg::Custom(provenance_msg) => {
-                CosmosMsg::Custom(ProvenanceMsgV2 {
-                    route: provenance_msg.route,
-                    params: provenance_msg.params,
-                    version: provenance_msg.version,
-                })
-            },
-            _ => panic!("unexpected message type provided to converter"),
-        }
-    }
-
-    pub fn from_prov(msg: ProvenanceMsg) -> ProvenanceMsgV2 {
-        ProvenanceMsgV2 { route: msg.route, params: msg.params, version: msg.version, }
-    }
-}
-/// Note: The linter does not like this, but it isn't seeing the derived JsonSchema, so it compiles
-/// fine.
-impl CustomMsg for ProvenanceMsgV2 {}

--- a/src/msg.rs
+++ b/src/msg.rs
@@ -1,4 +1,5 @@
-use cosmwasm_std::{Decimal, Uint128};
+use cosmwasm_std::{CosmosMsg, CustomMsg, Decimal, Uint128};
+use provwasm_std::{ProvenanceMsg, ProvenanceMsgParams, ProvenanceRoute};
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
@@ -59,3 +60,35 @@ pub type QueryResponse = State;
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
 #[serde(rename_all = "snake_case")]
 pub struct MigrateMsg {}
+
+/// FIXME: This will be fixed in 1.0.1-beta of provwasm.  This struct exists as a clone of
+/// FIXME: ProvenanceMsg, but implements CustomMsg.  CosmWasm 1.0.0-betaX does not allow exported
+/// FIXME: entry_point functions to expose Response<X> values, where X does not implement CustomMsg.
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
+#[serde(rename_all = "snake_case")]
+pub struct ProvenanceMsgV2 {
+    pub route: ProvenanceRoute,
+    pub params: ProvenanceMsgParams,
+    pub version: String,
+}
+impl ProvenanceMsgV2 {
+    pub fn from_cosmos(msg: CosmosMsg<ProvenanceMsg>) -> CosmosMsg<ProvenanceMsgV2> {
+        match msg {
+            CosmosMsg::Custom(provenance_msg) => {
+                CosmosMsg::Custom(ProvenanceMsgV2 {
+                    route: provenance_msg.route,
+                    params: provenance_msg.params,
+                    version: provenance_msg.version,
+                })
+            },
+            _ => panic!("unexpected message type provided to converter"),
+        }
+    }
+
+    pub fn from_prov(msg: ProvenanceMsg) -> ProvenanceMsgV2 {
+        ProvenanceMsgV2 { route: msg.route, params: msg.params, version: msg.version, }
+    }
+}
+/// Note: The linter does not like this, but it isn't seeing the derived JsonSchema, so it compiles
+/// fine.
+impl CustomMsg for ProvenanceMsgV2 {}


### PR DESCRIPTION
Provenance 1.8 is now released on testnet, and is not backwards compatible with provwasm 0.16.x / cosmwasm 0.16.x. These changes are required in order for a new version to be migrated.